### PR TITLE
qml: in listitem, expose wrapMode, elide, and maximumLineCount properties.

### DIFF
--- a/docs/types/listitem.md
+++ b/docs/types/listitem.md
@@ -10,6 +10,9 @@ Inherits: QtQuick.Controls 2.15 Button
 
 - [subText](#subtext): string
 - [iconOverlay](#iconoverlay): bool
+- [wrapMode](#wrapmode): int
+- [elide](#elide): int
+- [maximumLineCount](#maximumlinecount): int
 - [menu](#menu): [CutieMenu](menu)
 
 ## Detailed Description
@@ -22,7 +25,7 @@ Extends QtQuick.Controls 2 Button to function as a selectable item in [ListViews
 
 string
 
-An optional text shown below the actual text in `text` property. By default, this is shown using a smaller font size that the main text.
+An optional text shown below the actual text in the `text` property. By default, this is shown using a smaller font size than the main text.
 
 #### iconOverlay
 
@@ -30,8 +33,26 @@ bool
 
 If true, filters the icon to be colored black or white depending on the atmosphere variant. By default, this is set to true.
 
+#### wrapMode
+
+int
+
+Set this property to wrap the `text` and `subText` to the item's width. The text will only wrap if an explicit width has been set. Accepts standard QML `Text` wrap modes (e.g., `Text.Wrap`, `Text.NoWrap`). By default, this is set to `Text.Wrap`.
+
+#### elide
+
+int
+
+Set this property to elide parts of the `text` and `subText` if they do not fit within the item's width. Accepts standard QML `Text` elide modes (e.g., `Text.ElideRight`, `Text.ElideNone`). By default, this is set to `Text.ElideNone`.
+
+#### maximumLineCount
+
+int
+
+Set this property to limit the number of lines that the `text` and `subText` will span. By default, this is set to `-1` (no limit).
+
 #### menu
 
 [CutieMenu](menu)
 
-Can be set to add a context menu that will pop up on `pressAndHold` signal.
+Can be set to add a context menu that will pop up on the `pressAndHold` signal.

--- a/src/qml/Cutie/ListItem.qml
+++ b/src/qml/Cutie/ListItem.qml
@@ -10,6 +10,11 @@ Button {
 	width: parent.width
 	property string subText: ""
 	property bool iconOverlay: true
+    
+	property int wrapMode: Text.Wrap
+	property int elide: Text.ElideNone
+	property int maximumLineCount: -1
+    
 	property CutieMenu menu
 	padding: 15
 	bottomPadding: 10
@@ -99,7 +104,9 @@ Button {
 				text: root.text
 				font.pixelSize: 15
         		Layout.fillWidth: true
-				wrapMode: Text.Wrap
+				wrapMode: root.wrapMode
+				elide: root.elide
+				maximumLineCount: root.maximumLineCount
 			}
 			CutieLabel {
 				id: subTextItem
@@ -107,7 +114,9 @@ Button {
 				visible: root.subText !== ""
 				font.pixelSize: 10
         		Layout.fillWidth: true
-				wrapMode: Text.Wrap
+				wrapMode: root.wrapMode
+				elide: root.elide
+				maximumLineCount: root.maximumLineCount
 			}
 		}
 	}


### PR DESCRIPTION
Sometimes, if list items are loaded with very long text , like file names or music name. the item size becomes too big. this change allows limiting line count or enabling or disabling text wrap. Tested with music app.